### PR TITLE
re-work dockerfile to build from source and from raw alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,24 @@
-FROM frolvlad/alpine-bash
+from alpine as build-environment
+WORKDIR /opt
+RUN apk add clang lld curl build-base linux-headers \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
+    && chmod +x ./rustup.sh \
+    && ./rustup.sh -y
+WORKDIR /opt/foundry
+COPY . .
+RUN source $HOME/.profile && cargo build --release \
+    && strip /opt/foundry/target/release/forge \
+    && strip /opt/foundry/target/release/cast
 
-# copy all files
+from alpine as foundry-client
+ENV GLIBC_KEY=https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+ENV GLIBC_KEY_FILE=/etc/apk/keys/sgerrand.rsa.pub
+ENV GLIBC_RELEASE=https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk
 
-RUN apk update ; apk add --no-cache --allow-untrusted ca-certificates curl bash git jq
-
-ENV GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
-ENV GLIBC_VERSION=2.35-r0
-
-RUN set -ex && \
-    apk --update add libstdc++ curl ca-certificates && \
-    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
-        do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-    apk add --allow-untrusted /tmp/*.apk ; \
-    rm -v /tmp/*.apk ;/usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
-
-RUN apk add gcompat; echo "Sorry"
-WORKDIR /root
-
-RUN curl -L https://foundry.paradigm.xyz | bash; \
-    /bin/bash -c 'source $HOME/.bashrc'; \
-    /root/.foundry/bin/foundryup
-
-ENV PATH "$PATH:/root/.foundry/bin/"
-RUN echo "export PATH=${PATH}" >> $HOME/.bashrc;
+RUN apk add linux-headers gcompat
+RUN wget -q -O ${GLIBC_KEY_FILE} ${GLIBC_KEY} \
+    && wget -O glibc.apk ${GLIBC_RELEASE} \
+    && apk add glibc.apk --force
+COPY --from=build-environment /opt/foundry/target/release/forge /usr/local/bin/forge
+COPY --from=build-environment /opt/foundry/target/release/cast /usr/local/bin/cast
+ENTRYPOINT ["/bin/sh -c"]


### PR DESCRIPTION
This PR builds on your work from https://github.com/gakonst/foundry/pull/914. I am opening a PR here so that we can merge it down into your PR into foundry.

The dockerfile here builds `forge` and `cast` from a scratch alpine image using the latest source code. Final image size is 42.9MB, which is the smallest I could get it without having `solc` break in various ways.

Motivation to build from scratch rather than `rust:alpine` is the general fragility of using glibc stuff on alpine, and IMO having full control over the base image is ideal (since we discard everything but the binaries and required dependencies in the second stage anyway_